### PR TITLE
Add UnitTest import option with category

### DIFF
--- a/qgistester/tests/__init__.py
+++ b/qgistester/tests/__init__.py
@@ -75,7 +75,10 @@ def _testsFromModule(module, category='General'):
     modtests = []
     if 'functionalTests' in dir(module):
         modtests.extend(module.functionalTests())
-    if 'unitTests' in dir(module):
+
+    if 'unitTestsWithCategories' in dir(module):
+        modtests.extend([UnitTestWrapper(unit, cat) for unit, cat in module.unitTestsWithCategories()])
+    elif 'unitTests' in dir(module):
         modtests.extend([UnitTestWrapper(unit, category) for unit in module.unitTests()])
     if 'settings' in dir(module):
         for test in modtests:


### PR DESCRIPTION
I added the ability to use the categories also for unit tests (and not only for manual tests), so that in the test selector, unit tests don't all end up under the category "general".

To make use of this option, the user needs to put a function `unitTestsWithCategories()` to his `run_all_tests` module, returning a list with tuples of tests and categories instead of a list of tests like in `unitTests()`.

By the design of the code, the option is backwards compatible, if there is no `unitTestsWithCategories()`, the code still looks out for the `unitTests()` function.